### PR TITLE
Fix 'Id' suffix for property names

### DIFF
--- a/Example/generated/ProfileWizardPositionSaveEvent.swift
+++ b/Example/generated/ProfileWizardPositionSaveEvent.swift
@@ -9,8 +9,8 @@ import Analytics
 struct ProfileWizardPositionSaveEvent: ParametrizedInternalAnalyticsEvent, SlashAnalyticsEvent {
 
     enum ParameterKeys: String {
-        case buttonName
-        case type
+        case buttonName = "buttonName"
+        case type = "type"
     }
 
     enum `Type`: String {

--- a/Example/generated/SupportChatClickEvent.swift
+++ b/Example/generated/SupportChatClickEvent.swift
@@ -11,10 +11,10 @@ import Analytics
 struct SupportChatClickEvent: ParametrizedInternalAnalyticsEvent, SlashAnalyticsEvent {
 
     enum ParameterKeys: String {
-        case buttonName
-        case hhtmSource
-        case hhtmFrom
-        case employerId
+        case buttonName = "buttonName"
+        case hhtmSource = "hhtmSource"
+        case hhtmFrom = "hhtmFrom"
+        case employerID = "employerId"
     }
 
     let eventName = "button_click"
@@ -29,14 +29,14 @@ struct SupportChatClickEvent: ParametrizedInternalAnalyticsEvent, SlashAnalytics
     let hhtmFrom: HHTMSource?
 
     /// ID работодателя (если есть)
-    let employerId: String?
+    let employerID: String?
 
     var parameters: [ParameterKeys: Any?] {
         [
             .buttonName: buttonName,
             .hhtmSource: hhtmSource.value,
             .hhtmFrom: hhtmFrom?.value,
-            .employerId: employerId
+            .employerID: employerID
         ]
     }
 }

--- a/Sources/AnalyticsGen/Render/StencilExtensions/String/StencilStringWordModificator.swift
+++ b/Sources/AnalyticsGen/Render/StencilExtensions/String/StencilStringWordModificator.swift
@@ -19,10 +19,6 @@ final class StencilStringWordModificator: StencilStringModificator {
             return string
         }
 
-        guard let range = string.range(of: word, options: .caseInsensitive) else {
-            return string
-        }
-
-        return string[range].uppercased() + string[range.upperBound ..< string.endIndex]
+        return string.replacingOccurrences(of: word, with: word.uppercased(), options: .caseInsensitive)
     }
 }

--- a/Templates/ExternalInternalEvent.stencil
+++ b/Templates/ExternalInternalEvent.stencil
@@ -1,5 +1,5 @@
 {% include "FileHeader.stencil" %}
-{% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstLetter|escapeReservedKeywords }}{% endmacro %}
+{% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstLetter|escapeReservedKeywords|upperWord:"id" }}{% endmacro %}
 {% macro enumName name %}{{ name|swiftIdentifier:"pretty"|escapeReservedKeywords }}{% endmacro %}
 {% set hasParameters %}{% if event.internal.parameters.count > 0 %}true{% else %}{% endif %}{% endset %}
 {% set internalAnalyticsEventType %}{% if hasParameters %}ParametrizedInternalAnalyticsEvent{% else %}InternalAnalyticsEvent{% endif %}{% endset %}
@@ -17,7 +17,7 @@ struct {{ filename }}: {{ internalAnalyticsEventType }}, SlashAnalyticsEvent, Us
     {% if hasParameters %}
     enum ParameterKeys: String {
         {% for parameter in event.internal.parameters %}
-        case {% call propertyName parameter.name %}
+        case {% call propertyName parameter.name %} = "{{ parameter.name }}"
         {% endfor %}
     }
     {% endif %}

--- a/Templates/InternalEvent.stencil
+++ b/Templates/InternalEvent.stencil
@@ -1,5 +1,5 @@
 {% include "FileHeader.stencil" %}
-{% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstLetter|escapeReservedKeywords }}{% endmacro %}
+{% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstLetter|escapeReservedKeywords|upperWord:"id" }}{% endmacro %}
 {% macro enumName name %}{{ name|swiftIdentifier:"pretty"|escapeReservedKeywords|upperWord:"hhtm" }}{% endmacro %}
 {% set hasParameters %}{% if event.internal.parameters.count > 0 %}true{% else %}{% endif %}{% endset %}
 {% set internalAnalyticsEventType %}{% if hasParameters %}ParametrizedInternalAnalyticsEvent{% else %}InternalAnalyticsEvent{% endif %}{% endset %}
@@ -21,7 +21,7 @@ struct {{ filename }}: {{ internalAnalyticsEventType }}, SlashAnalyticsEvent {
     {% if hasParameters %}
     enum ParameterKeys: String {
         {% for parameter in event.internal.parameters %}
-        case {% call propertyName parameter.name %}
+        case {% call propertyName parameter.name %} = "{{ parameter.name }}"
         {% endfor %}
     }
     {% endif %}


### PR DESCRIPTION
Parameter with name:
```yaml
  employerId:
    description: ID работодателя (если есть)
    type: string?
```
Will be generated as:
```swift
    enum ParameterKeys: String {
        case employerID = "employerId"
    }

    /// ID работодателя (если есть)
    let employerID: String?
```