### PR TITLE
Fallback for GitHub access token

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/analyticsgen.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/analyticsgen.xcscheme
@@ -74,6 +74,12 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "generate"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/AnalyticsGen/Models/Configuration/AccessTokenConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/AccessTokenConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum AccessTokenConfiguration: Decodable {
+struct AccessTokenConfiguration: Decodable {
 
     // MARK: - Nested Types
 
@@ -19,23 +19,23 @@ enum AccessTokenConfiguration: Decodable {
         let key: String
     }
 
-    // MARK: - Enumeration Cases
+    // MARK: - Instance Properties
 
-    case environmentVariable(String)
-    case keychain(KeychainParameters)
-    case value(String)
+    let value: String?
+    let environmentVariable: String?
+    let keychainParameters: KeychainParameters?
 
     // MARK: - Initializers
 
     init(from decoder: Decoder) throws {
         if let container = try? decoder.container(keyedBy: CodingKeys.self) {
-            if let value = try container.decodeIfPresent(String.self, forKey: .environmentVariable) {
-                self = .environmentVariable(value)
-            } else {
-                self = .keychain(try container.decode(forKey: .keychain))
-            }
+            self.value = nil
+            self.environmentVariable = try container.decodeIfPresent(forKey: .environmentVariable)
+            self.keychainParameters = try container.decodeIfPresent(forKey: .keychain)
         } else {
-            self = .value(try String(from: decoder))
+            self.value = try String(from: decoder)
+            self.environmentVariable = nil
+            self.keychainParameters = nil
         }
     }
 }


### PR DESCRIPTION
You can now simultaneously use GitHub access token from environment and keychain. If token will not be found in environment variables, then token will be try obtaining from Keychain. Example configuration:
```yaml
source:
  gitHub:
    ...
    accessToken:
      env: GITHUB_API_TOKEN
      keychain:
        service: GitHub Token
        key: hh
...
```