### PR TITLE
Add support for multiple targets

### DIFF
--- a/Sources/AnalyticsGen/Generators/GenerationParametersResolving.swift
+++ b/Sources/AnalyticsGen/Generators/GenerationParametersResolving.swift
@@ -10,7 +10,7 @@ protocol GenerationParametersResolving {
 
     // MARK: - Instance Methods
 
-    func resolveGenerationParameters(from configuration: Configuration) throws -> GenerationParameters
+    func resolveGenerationParameters(from configuration: GeneratedConfiguration) throws -> GenerationParameters
 }
 
 // MARK: -
@@ -19,7 +19,7 @@ extension GenerationParametersResolving {
 
     // MARK: - Instance Methods
 
-    private func resolveInternalTemplateType(configuration: Configuration) -> RenderTemplateType {
+    private func resolveInternalTemplateType(configuration: GeneratedConfiguration) -> RenderTemplateType {
         if let templatesPath = configuration.template?.internal?.path {
             return .custom(path: templatesPath)
         } else {
@@ -27,7 +27,7 @@ extension GenerationParametersResolving {
         }
     }
 
-    private func resolveExternalTemplateType(configuration: Configuration) -> RenderTemplateType {
+    private func resolveExternalTemplateType(configuration: GeneratedConfiguration) -> RenderTemplateType {
         if let templatesPath = configuration.template?.external?.path {
             return .custom(path: templatesPath)
         } else {
@@ -35,7 +35,7 @@ extension GenerationParametersResolving {
         }
     }
 
-    private func resolveDestination(configuration: Configuration) -> RenderDestination {
+    private func resolveDestination(configuration: GeneratedConfiguration) -> RenderDestination {
         if let destinationPath = configuration.destination {
             return .file(path: destinationPath)
         } else {
@@ -45,7 +45,7 @@ extension GenerationParametersResolving {
 
     // MARK: -
 
-    func resolveGenerationParameters(from configuration: Configuration) throws -> GenerationParameters {
+    func resolveGenerationParameters(from configuration: GeneratedConfiguration) throws -> GenerationParameters {
         let internalTemplateType = resolveInternalTemplateType(configuration: configuration)
         let externalTemplateType = resolveExternalTemplateType(configuration: configuration)
 

--- a/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
@@ -26,7 +26,7 @@ struct Configuration: Decodable {
                     destination: destination,
                     platform: platform,
                     template: template,
-                    name: nil
+                    name: "Main"
                 )
             ]
         }

--- a/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
@@ -2,11 +2,33 @@ import Foundation
 import AnalyticsGenTools
 
 struct Configuration: Decodable {
-
-    // MARK: - Instance Properties
-
     let source: SourceConfiguration
     let destination: String?
     let platform: EventPlatform?
     let template: TemplateConfiguration?
+    let targets: [Target]?
+
+    var configurations: [GeneratedConfiguration] {
+        if let targets = targets {
+            return targets.map { target in
+                GeneratedConfiguration(
+                    source: SourceConfiguration(source: source, target: target),
+                    destination: target.destination ?? destination,
+                    platform: target.platform ?? platform,
+                    template: template,
+                    name: target.name
+                )
+            }
+        } else {
+            return [
+                GeneratedConfiguration(
+                    source: source,
+                    destination: destination,
+                    platform: platform,
+                    template: template,
+                    name: nil
+                )
+            ]
+        }
+    }
 }

--- a/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
@@ -1,0 +1,13 @@
+import Foundation
+import AnalyticsGenTools
+
+struct GeneratedConfiguration {
+
+    // MARK: - Instance Properties
+
+    let source: SourceConfiguration
+    let destination: String?
+    let platform: EventPlatform?
+    let template: TemplateConfiguration?
+    let name: String?
+}

--- a/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
@@ -9,5 +9,5 @@ struct GeneratedConfiguration {
     let destination: String?
     let platform: EventPlatform?
     let template: TemplateConfiguration?
-    let name: String?
+    let name: String
 }

--- a/Sources/AnalyticsGen/Models/Configuration/SourceConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/SourceConfiguration.swift
@@ -26,3 +26,22 @@ enum SourceConfiguration: Decodable {
         }
     }
 }
+
+extension SourceConfiguration {
+    init(source: SourceConfiguration, target: Target) {
+        switch source {
+        case .local:
+            self = source
+        case let .gitHub(configuration: configuration):
+            self = .gitHub(
+                configuration: GitHubSourceConfiguration(
+                    owner: configuration.owner,
+                    repo: configuration.repo,
+                    path: target.path ?? configuration.path,
+                    ref: target.ref ?? configuration.ref,
+                    accessToken: configuration.accessToken
+                )
+            )
+        }
+    }
+}

--- a/Sources/AnalyticsGen/Models/Configuration/Target.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/Target.swift
@@ -1,0 +1,11 @@
+import Foundation
+import AnalyticsGenTools
+
+struct Target: Decodable {
+    
+    let name: String
+    let platform: EventPlatform?
+    let path: String?
+    let destination: String?
+    let ref: GitHubReferenceConfiguration?
+}

--- a/Sources/AnalyticsGen/Providers/FileProvider/FileProvider.swift
+++ b/Sources/AnalyticsGen/Providers/FileProvider/FileProvider.swift
@@ -6,9 +6,11 @@ protocol FileProvider {
 
     func readFile<FileContent: Decodable>(at path: String) throws -> FileContent
     func readFile<FileContent: Decodable>(at path: String) -> Promise<FileContent>
+    func readFile<FileContent: Decodable>(at path: String, type: FileContent.Type) -> Promise<FileContent>
 
     func readFileIfExists<FileContent: Decodable>(at path: String) throws -> FileContent?
     func readFileIfExists<FileContent: Decodable>(at path: String) -> Promise<FileContent?>
+    func readFileIfExists<FileContent: Decodable>(at path: String, type: FileContent.Type) -> Promise<FileContent?>
 
     func writeFile<FileContent: Encodable>(content: FileContent, at path: String) throws
 }
@@ -24,10 +26,18 @@ extension FileProvider {
             seal.fulfill(try readFile(at: path))
         }
     }
+    
+    func readFile<FileContent: Decodable>(at path: String, type: FileContent.Type) -> Promise<FileContent> {
+        readFile(at: path)
+    }
 
     func readFileIfExists<FileContent: Decodable>(at path: String) -> Promise<FileContent?> {
         Promise { seal in
             seal.fulfill(try readFileIfExists(at: path))
         }
+    }
+    
+    func readFileIfExists<FileContent: Decodable>(at path: String, type: FileContent.Type) -> Promise<FileContent?> {
+        readFileIfExists(at: path)
     }
 }


### PR DESCRIPTION
New .analyticsGen scheme would be 
```yaml
source:
  gitHub:
    owner: hhru
    repo: hh-mobile-analytics
    ref:
      tag: 1.7.26
    accessToken:
      env: GITHUB_API_TOKEN
      keychain:
        service: GitHub Token
        key: hh
platform: iOS
targets:
  - name: Applicant
    path: schemas/applicant
    destination: Features/Shared/Foundation/AnalyticsEvents/Sources/Generated/AnalyticsGen/
  - name: HR-Mobile
    path: schemas/hr-mobile
    destination: Features/Shared/Foundation/AnalyticsEvents/Sources/Generated/AnalyticsGen/HR-Mobile
    ref:
      branch: PORTFOLIO-18301
template:
  internal:
    options:
      publicAccess: true
  external:
    options:
      publicAccess: true
```