### PR TITLE
Update configuration models for finders

### DIFF
--- a/Example/.analyticsGen.yml
+++ b/Example/.analyticsGen.yml
@@ -1,6 +1,67 @@
-source: schemas
-destination: generated
+source:
+  gitHub:
+    owner: hhru
+    repo: hh-mobile-analytics
+    ref:
+      finders:
+        - type: matched_tag
+          source:
+            type:
+              env:
+                - GIT_BRANCH
+                - GIT_MERGE_BRANCH
+            condition:
+              type: regex
+              value: ^PORTFOLIO-\d+$
+        - type: first_merged
+          skip:
+            source:
+              type:
+                env:
+                  - GIT_BRANCH
+                  - GIT_MERGE_BRANCH
+              condition:
+                type: const
+                value: develop
+          branch: develop
+          condition:
+            type: regex
+            value: ^PORTFOLIO-\d+$
+        - type: matched_tag
+          source:
+            type:
+              file:
+                - path: Configurations/Personal.xcconfig
+                  variable: ANALYTICS_REF
+            condition:
+              type: regex
+              value: ^PORTFOLIO-\d+$
+        - type: matched_tag
+          source:
+            type: git
+            condition:
+              type: regex
+              value: ^PORTFOLIO-\d+$
+        - type: last_tag
+        - type: last_commit
+          branch: master
+    accessToken:
+      env: GITHUB_API_TOKEN
+      keychain:
+        service: GitHub Token
+        key: hh
 platform: iOS
+targets:
+  - name: Applicant
+    path: schemas/applicant
+    destination: Features/Shared/Foundation/AnalyticsEvents/Sources/Generated/AnalyticsGen/Applicant
+    ref:
+      tag: 2.0
+  - name: HR-Mobile
+    path: schemas/hr-mobile
+    destination: Features/Shared/Foundation/AnalyticsEvents/Sources/Generated/AnalyticsGen/HR-Mobile
+    ref:
+      tag: 2.0
 template:
   internal:
     options:

--- a/Example/.analyticsGen.yml
+++ b/Example/.analyticsGen.yml
@@ -13,7 +13,7 @@ source:
             condition:
               type: regex
               value: ^PORTFOLIO-\d+$
-        - type: first_merged
+        - type: last_merged
           skip:
             source:
               type:

--- a/Sources/AnalyticsGen/Models/Configuration/AccessTokenConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/AccessTokenConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct AccessTokenConfiguration: Decodable {
+struct AccessTokenConfiguration: Decodable, Equatable {
 
     // MARK: - Nested Types
 
@@ -11,7 +11,7 @@ struct AccessTokenConfiguration: Decodable {
 
     // MARK: -
 
-    struct KeychainParameters: Decodable {
+    struct KeychainParameters: Decodable, Equatable {
 
         // MARK: - Instance Properties
 
@@ -37,5 +37,11 @@ struct AccessTokenConfiguration: Decodable {
             self.environmentVariable = nil
             self.keychainParameters = nil
         }
+    }
+
+    init(value: String? = nil, environmentVariable: String?, keychainParameters: KeychainParameters?) {
+        self.value = value
+        self.environmentVariable = environmentVariable
+        self.keychainParameters = keychainParameters
     }
 }

--- a/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/Configuration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AnalyticsGenTools
 
-struct Configuration: Decodable {
+struct Configuration: Decodable, Equatable {
     let source: SourceConfiguration
     let destination: String?
     let platform: EventPlatform?

--- a/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GeneratedConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AnalyticsGenTools
 
-struct GeneratedConfiguration {
+struct GeneratedConfiguration: Equatable {
 
     // MARK: - Instance Properties
 

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/FinderConditionConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/FinderConditionConfiguration.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum FinderConditionConfiguration: Decodable, Equatable {
+    case regex(String)
+    case const(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawType = try container.decode(RawType.self, forKey: .type)
+        let value = try container.decode(String.self, forKey: .value)
+
+        switch rawType {
+        case .regex:
+            self = .regex(value)
+
+        case .const:
+            self = .const(value)
+        }
+    }
+}
+
+extension FinderConditionConfiguration {
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+    }
+
+    private enum RawType: String, Decodable {
+        case regex
+        case const
+    }
+}

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/FinderSourceConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/FinderSourceConfiguration.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct FinderSourceConfiguration: Decodable, Equatable {
+    enum SourceType: Equatable {
+        struct File: Decodable, Equatable {
+            let path: String
+            let variable: String
+        }
+
+        case environment(variables: [String])
+        case file(files: [File])
+        case git
+    }
+
+    let type: SourceType
+    let condition: FinderConditionConfiguration
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let environment = try? container.decode(EnvironmentVariables.self, forKey: .type) {
+            self.type = .environment(variables: environment.env)
+        } else if let files = try? container.decode(Files.self, forKey: .type) {
+            self.type = .file(files: files.file)
+        } else if let rawType = try? container.decode(String.self, forKey: .type), rawType == "git" {
+            self.type = .git
+        } else {
+            throw DecodingError.typeMismatch(
+                SourceType.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid source type, expected 'env' 'file' or 'git'",
+                    underlyingError: nil
+                )
+            )
+        }
+
+        self.condition = try container.decode(forKey: .condition)
+    }
+
+    init(type: SourceType, condition: FinderConditionConfiguration) {
+        self.type = type
+        self.condition = condition
+    }
+}
+
+extension FinderSourceConfiguration {
+
+    private struct EnvironmentVariables: Decodable {
+        let env: [String]
+    }
+
+    private struct Files: Decodable {
+        let file: [SourceType.File]
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case env
+        case file
+        case git
+        case condition
+    }
+}

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderConfiguration.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct GitHubReferenceFinderConfiguration: Decodable, Equatable {
+
+    let type: GitHubReferenceFinderTypeConfiguration
+    let skipCondition: FinderSourceConfiguration?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawType = try container.decode(RawType.self, forKey: .type)
+
+        switch rawType {
+        case .matchedTag:
+            self.type = .matchedTag(
+                source: try container.decode(forKey: .source)
+            )
+
+        case .firstMerged:
+            self.type = .firstMerged(
+                branch: try container.decode(forKey: .branch),
+                condition: try container.decode(forKey: .condition)
+            )
+
+        case .lastTag:
+            self.type = .lastTag
+
+        case .lastCommit:
+            self.type = .lastCommit(
+                branch: try container.decode(forKey: .branch)
+            )
+        }
+
+        self.skipCondition = try container
+            .decodeIfPresent(Skip.self, forKey: .skip)?
+            .source
+    }
+
+    init(type: GitHubReferenceFinderTypeConfiguration, skipCondition: FinderSourceConfiguration? = nil) {
+        self.type = type
+        self.skipCondition = skipCondition
+    }
+}
+
+extension GitHubReferenceFinderConfiguration {
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case source
+        case branch
+        case condition
+        case skip
+    }
+
+    private enum RawType: String, Decodable {
+        case matchedTag = "matched_tag"
+        case firstMerged = "first_merged"
+        case lastTag = "last_tag"
+        case lastCommit = "last_commit"
+    }
+
+    private struct Skip: Decodable {
+        let source: FinderSourceConfiguration
+    }
+}

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderConfiguration.swift
@@ -15,8 +15,8 @@ struct GitHubReferenceFinderConfiguration: Decodable, Equatable {
                 source: try container.decode(forKey: .source)
             )
 
-        case .firstMerged:
-            self.type = .firstMerged(
+        case .lastMerged:
+            self.type = .lastMerged(
                 branch: try container.decode(forKey: .branch),
                 condition: try container.decode(forKey: .condition)
             )
@@ -53,7 +53,7 @@ extension GitHubReferenceFinderConfiguration {
 
     private enum RawType: String, Decodable {
         case matchedTag = "matched_tag"
-        case firstMerged = "first_merged"
+        case lastMerged = "last_merged"
         case lastTag = "last_tag"
         case lastCommit = "last_commit"
     }

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderTypeConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderTypeConfiguration.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum GitHubReferenceFinderTypeConfiguration: Equatable {
+    case matchedTag(source: FinderSourceConfiguration)
+    case firstMerged(branch: String, condition: FinderConditionConfiguration)
+    case lastTag
+    case lastCommit(branch: String)
+}

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderTypeConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/Finder/GitHubReferenceFinderTypeConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum GitHubReferenceFinderTypeConfiguration: Equatable {
     case matchedTag(source: FinderSourceConfiguration)
-    case firstMerged(branch: String, condition: FinderConditionConfiguration)
+    case lastMerged(branch: String, condition: FinderConditionConfiguration)
     case lastTag
     case lastCommit(branch: String)
 }

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/GitHubReferenceConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/GitHubReferenceConfiguration.swift
@@ -1,21 +1,12 @@
 import Foundation
 
-enum GitHubReferenceConfiguration: Decodable {
-
-    // MARK: - Nested Types
-
-    enum CodingKeys: String, CodingKey {
-
-        // MARK: - Enumeration Cases
-
-        case branch
-        case tag
-    }
+enum GitHubReferenceConfiguration: Decodable, Equatable {
 
     // MARK: - Enumeration Cases
 
     case branch(String)
     case tag(String)
+    case finders([GitHubReferenceFinderConfiguration])
 
     // MARK: - Instance Properties
 
@@ -23,6 +14,9 @@ enum GitHubReferenceConfiguration: Decodable {
         switch self {
         case .branch(let name), .tag(let name):
             return name
+
+        case .finders:
+            fatalError("TODO: Вынести отсюда в следующей задаче")
         }
     }
 
@@ -35,15 +29,29 @@ enum GitHubReferenceConfiguration: Decodable {
             self = .branch(branchName)
         } else if let tagName = try container.decodeIfPresent(String.self, forKey: .tag) {
             self = .tag(tagName)
+        } else if let finders = try container.decodeIfPresent([GitHubReferenceFinderConfiguration].self, forKey: .finders) {
+            self = .finders(finders)
         } else {
             throw DecodingError.typeMismatch(
                 GitHubReferenceConfiguration.self,
                 DecodingError.Context(
                     codingPath: decoder.codingPath,
-                    debugDescription: "Invalid reference, expected 'branch' or 'tag'",
+                    debugDescription: "Invalid reference, expected 'branch', 'tag' or 'finders'",
                     underlyingError: nil
                 )
             )
         }
+    }
+}
+
+extension GitHubReferenceConfiguration {
+
+    private enum CodingKeys: String, CodingKey {
+
+        // MARK: - Enumeration Cases
+
+        case branch
+        case tag
+        case finders
     }
 }

--- a/Sources/AnalyticsGen/Models/Configuration/GitHub/GitHubSourceConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/GitHub/GitHubSourceConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GitHubSourceConfiguration: Decodable {
+struct GitHubSourceConfiguration: Decodable, Equatable {
 
     // MARK: - Instance Properties
 

--- a/Sources/AnalyticsGen/Models/Configuration/SourceConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/SourceConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum SourceConfiguration: Decodable {
+enum SourceConfiguration: Decodable, Equatable {
 
     // MARK: - Nested Types
 

--- a/Sources/AnalyticsGen/Models/Configuration/Target.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/Target.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AnalyticsGenTools
 
-struct Target: Decodable {
+struct Target: Decodable, Equatable {
     
     let name: String
     let platform: EventPlatform?

--- a/Sources/AnalyticsGen/Models/Configuration/TemplateConfiguration.swift
+++ b/Sources/AnalyticsGen/Models/Configuration/TemplateConfiguration.swift
@@ -1,11 +1,11 @@
 import Foundation
 import AnalyticsGenTools
 
-struct TemplateConfiguration: Decodable {
+struct TemplateConfiguration: Decodable, Equatable {
 
     // MARK: - Nested Types
 
-    struct Template: Decodable {
+    struct Template: Decodable, Equatable {
 
         // MARK: - Instance Properties
 

--- a/Sources/AnalyticsGen/Providers/GitHub/RemoteRepoProvider+GitHub.swift
+++ b/Sources/AnalyticsGen/Providers/GitHub/RemoteRepoProvider+GitHub.swift
@@ -68,6 +68,9 @@ private extension GitHubReferenceConfiguration {
 
         case .branch(let name):
             return "heads/\(name)"
+
+        case .finders:
+            fatalError("Логика резолва в следующей задаче")
         }
     }
 }


### PR DESCRIPTION
Данные из репозитория могут браться из динамичного тега или ветки. Для этого появилась новая сущность, которая описывает логику поиска – `finder`. Можно перечислить несколько `finder`, которые один за другим будут выполняться, пока не будет найден нужный тег или коммит.
Если тега с нужным названием не будет найдено в git, то будет использоваться следующий `finder`, либо генератор завершается с ошибкой.
## Примеры
### Поиск названия тега из выбранного источника
Пример поиска названия тега по регулярному выражению с названием указанным в одной из окружений переменных. Если значение из `GIT_BRANCH` или `GIT_MERGE_BRANCH` будут соответствовать регулярному выражению `^PORTFOLIO-\d+$`, то тег с этим именем будет использоваться для генерации аналитики.
```yaml
finders:
  - type: matched_tag
    source:
      type:
        env:
          - GIT_BRANCH
          - GIT_MERGE_BRANCH
      condition:
        type: regex
        value: ^PORTFOLIO-\d+$
```
Поиск также может производится в файлах. В данном примере будет произведёт поиск в файле значения, указанного в формате `ANALYTICS_REF = {value}`. Если `value` будет соответствовать регулярному выражению `^PORTFOLIO-\d+$`, то тег с этим именем будет использоваться для генерации аналитики.
```yaml
finders:
  - type: matched_tag
    source:
      type:
        file:
          - path: Configurations/Personal.xcconfig
            variable: ANALYTICS_REF
      condition:
        type: regex
        value: ^PORTFOLIO-\d+$
```
### Поиск названия тега из названия последней смержённой ветки
Пример поиска названия тега по мерж коммитам в ветку `develop`. Название смерженной ветки должно соответствовать регулярному выражению `^PORTFOLIO-\d+$`. Последняя найденная такая ветка будет использоваться как название для тега. 
Дополнительно здесь указан параметр `skip`, который позволяет пропустить данный `finder` и не выполнять поиск, если тому не соответствует `source` с `condition`.
```yaml
finders:
  - type: last_merged
    skip:
      source:
        type:
          env:
            - GIT_BRANCH
            - GIT_MERGE_BRANCH
        condition:
          type: const
          value: develop
    branch: develop
    condition:
      type: regex
      value: ^PORTFOLIO-\d+$
```
### Поиск последнего тега из git
Последний по дате тег из git репозитория будет использован для генерации аналитики.
```yaml
finders:
  - type: last_tag
```
### Поиск последнего коммита из ветки
Последний коммит из ветки `master` будет использовать для генерации аналитики.
```yaml
finders:
  - type: last_commit
    branch: master
```