### PR TITLE
Add support for specific external analytics tracker protocols in Stencil

### DIFF
--- a/Sources/AnalyticsGen/Generators/Event/DefaultEventGenerator.swift
+++ b/Sources/AnalyticsGen/Generators/Event/DefaultEventGenerator.swift
@@ -80,6 +80,20 @@ final class DefaultEventGenerator: EventGenerator {
         return parameters
     }
 
+    private func resolveEventProtocol(event: ExternalEvent) -> String {
+        let protocolName: String
+        switch event.tracker {
+            case .appsFlyer: 
+                protocolName = "AppsFlyerEvent"
+            case .appMetrica: 
+                protocolName = "AppMetricaEvent"
+            case .none: 
+                protocolName = "AllExternalAnalyticsEvent"
+        }
+
+        return protocolName
+    }
+
     private func generate(
         parameters: GenerationParameters,
         event: Event,
@@ -165,6 +179,7 @@ final class DefaultEventGenerator: EventGenerator {
                             oneOf: label.oneOf
                         )
                     },
+                    eventProtocol: resolveEventProtocol(event: externalEvent),
                     initialisationParameters: resolveExternalEventInitialisationParameters(event: externalEvent)
                 )
             )

--- a/Sources/AnalyticsGen/Generators/Event/ExternalEventContext.swift
+++ b/Sources/AnalyticsGen/Generators/Event/ExternalEventContext.swift
@@ -53,5 +53,6 @@ struct ExternalEventContext: Encodable {
     let schemePath: String
     let action: Action
     let label: Label?
+    let eventProtocol: String
     let initialisationParameters: [Parameter]
 }

--- a/Sources/AnalyticsGen/Models/Event/External/ExternalEvent.swift
+++ b/Sources/AnalyticsGen/Models/Event/External/ExternalEvent.swift
@@ -9,4 +9,5 @@ struct ExternalEvent: Decodable {
     let forContractor: Bool?
     let label: ExternalEventLabel?
     let platform: EventPlatform?
+    let tracker: ExternalEventTracker?
 }

--- a/Sources/AnalyticsGen/Models/Event/External/ExternalEventTracker.swift
+++ b/Sources/AnalyticsGen/Models/Event/External/ExternalEventTracker.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum ExternalEventTracker: Decodable {
+    case appsFlyer
+    case appMetrica
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self).lowercased()
+
+        switch rawValue {
+        case "appsflyer":
+            self = .appsFlyer
+        case "appmetrica":
+            self = .appMetrica
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown tracker value: \(rawValue)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
- Introduced ability to specify protocol based on the external tracker defined in the YAML schema
- Added mapping for AppsFlyerEvent, AppMetricaEvent and default AllExternalAnalyticsEvent
- Updated Stencil templates to use the resolved protocol dynamically instead of a hardcoded default